### PR TITLE
Add option to install brew without zsh

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ This script can also be used just to install brew without zsh.
 bash <(curl -fsSl https://raw.githubusercontent.com/CP-STA/sta-setup/master/setup.sh) -B
 ```
 
-Add `eval "$($HOME/.linuxbrew/bin/brew shellenv)"` to the end of your `~/.bashrc` file.
+Restart your shell for the changes to take effect.
 
 # Features
 1. linuxbrew, with which you can install up-to-date packages without asking admins.

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,8 @@ This script can also be used just to install brew without zsh.
 bash <(curl -fsSl https://raw.githubusercontent.com/CP-STA/sta-setup/master/setup.sh) -B
 ```
 
+Add `eval "$($HOME/.linuxbrew/bin/brew shellenv)"` to the end of your `~/.bashrc` file.
+
 # Features
 1. linuxbrew, with which you can install up-to-date packages without asking admins.
 2. A working and up-to-date gcc complier.

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,14 @@ The machines in the labs can sometimes be quite difficult to work especially wit
 
 And then restart your shell for it to take effect.
 
+## Brew only installation
+
+This script can also be used just to install brew without zsh.
+
+```bash
+bash -c "$(curl -fsSl https://raw.githubusercontent.com/STAOJ/sta-setup/master/setup.sh)" -- -h
+```
+
 # Features
 1. linuxbrew, with which you can install up-to-date packages without asking admins.
 2. A working and up-to-date gcc complier.

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ The machines in the labs can sometimes be quite difficult to work especially wit
 
 # Installation
 ```bash
-/usr/bin/env bash -c "$(curl -fsSL https://raw.githubusercontent.com/STAOJ/sta-setup/master/setup.sh)"
+bash <(curl -fsSl https://raw.githubusercontent.com/CP-STA/sta-setup/master/setup.sh)
 ```
 
 And then restart your shell for it to take effect.
@@ -13,7 +13,7 @@ And then restart your shell for it to take effect.
 This script can also be used just to install brew without zsh.
 
 ```bash
-bash -c "$(curl -fsSl https://raw.githubusercontent.com/STAOJ/sta-setup/master/setup.sh)" -- -h
+bash <(curl -fsSl https://raw.githubusercontent.com/CP-STA/sta-setup/master/setup.sh) -B
 ```
 
 # Features

--- a/setup.sh
+++ b/setup.sh
@@ -41,7 +41,7 @@ stasetup::install_brew () {
 
 stasetup::install_zsh () {
     originaldir=$(pwd)
-    
+
     ## copied from old setup script, with brew bits removed
     cd ${HOME}
     NO_SHELL=false
@@ -131,7 +131,6 @@ if [ "${BASH_SOURCE[0]}" == "$0" ]; then
 
     echo "Installing brew"
     stasetup::install_brew
-    stasetup::install_gcc
     
     if [[ $install_zsh = true ]]; then
         echo "Installing zsh"

--- a/setup.sh
+++ b/setup.sh
@@ -118,20 +118,9 @@ usage () {
 }
 
 # run if the script is directly executed (not sourced)
-
- # See https://stackoverflow.com/a/28776166
- is_sourced() {
-   if [ -n "$ZSH_VERSION" ]; then 
-       case $ZSH_EVAL_CONTEXT in *:file:*) return 0;; esac
-   else  # Add additional POSIX-compatible shell names here, if needed.
-       case ${0##*/} in dash|-dash|bash|-bash|ksh|-ksh|sh|-sh) return 0;; esac
-   fi
-   return 1  # NOT sourced.
- }
-
-
-if [ "$(is_sourced)" = true ]; then 
+if [ "${BASH_SOURCE[0]}" == "$0" ]; then 
     install_zsh=true
+    
     while getopts "hB" arg; do
         case $arg in
             h) usage; exit 0;;

--- a/setup.sh
+++ b/setup.sh
@@ -16,7 +16,7 @@
 add_to_rc () {
     for shell_file in "$HOME/.bashrc" "$HOME/.zshrc"; do
         if  [ -f "$shell_file" ]; then
-            append_if_not_present $1 $shell_file
+            append_if_not_present "$1" "$shell_file"
         fi
     done
 }
@@ -29,7 +29,7 @@ add_to_rc () {
 #######################################
 
 append_if_not_present () {
-grep -qx $1 $2 || echo $1 >> $2
+grep -qx "$1" "$2" || echo "$1" >> "$2"
 }
 
 #######################################
@@ -43,17 +43,19 @@ grep -qx $1 $2 || echo $1 >> $2
 stasetup::install_brew () {
     set -e 
     originaldir=$(pwd)
+    if [ ! -d "$HOME/.linuxbrew" ]; then
+        git clone https://github.com/Homebrew/brew "$HOME/.linuxbrew"
+    fi
 
-    git clone https://github.com/Homebrew/brew ${HOME}/.linuxbrew
     $HOME/.linuxbrew/bin/brew update --force --quiet
     eval "$($HOME/.linuxbrew/bin/brew shellenv)"
     brew install --force-bottle binutils
     brew install --force-bottle gcc
     cd "$HOMEBREW_PREFIX/bin"
-    ln -s gcc-11 gcc 
-    ln -s g++-11 g++ 
-    ln -s cpp-11 cpp 
-    ln -s c++-11 c++
+    ln -sf gcc-11 gcc 
+    ln -sf g++-11 g++ 
+    ln -sf cpp-11 cpp 
+    ln -sf c++-11 c++
 
 
     add_to_rc 'eval "$($HOME/.linuxbrew/bin/brew shellenv)"'

--- a/setup.sh
+++ b/setup.sh
@@ -1,76 +1,145 @@
 #!/usr/bin/env bash
 
-cd ${HOME}
-git clone https://github.com/Homebrew/brew ${HOME}/.linuxbrew
-.linuxbrew/bin/brew update --force --quiet
-eval "$(${HOME}/.linuxbrew/bin/brew shellenv)"
-brew install --force-bottle binutils
-brew install --force-bottle gcc
-brew install zsh
+# Install zsh and/or brew, configured for St Andrews CS lab PCs / host servers.
 
-cd ${HOMEBREW_PREFIX}/bin
-ln -s gcc-11 gcc 
-ln -s g++-11 g++ 
-ln -s cpp-11 cpp 
-ln -s c++-11 c++
+# Usage: see -h / usage()
 
-cd ${HOME}
-NO_SHELL=false
-if [ -n "$BASH_VERSION" ]; then
-  echo "$(which zsh)" >> ${HOME}/.bashrc
-elif [ -n "$ZSH_VERSION" ]; then
-  :
-else
-  NO_SHELL=true
-fi
+#######################################
+# Installs brew under the local user from git.
+# Globals:
+#   HOME
+# Arguments:
+#   None
+#######################################
 
-git clone https://github.com/ohmyzsh/ohmyzsh.git ${HOME}/.oh-my-zsh
-git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
-git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
-git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+stasetup::install_brew () {
+    git clone https://github.com/Homebrew/brew ${HOME}/.linuxbrew
+    .linuxbrew/bin/brew update --force --quiet
+    eval "$(${HOME}/.linuxbrew/bin/brew shellenv)"
+    brew install --force-bottle binutils
+}
 
-if [ -f "${HOME}/.zshrc" ]; then
-  ZSHRC_BACKUP="${HOME}/.zshrc.backup"
-  while [ -f "${ZSHRC_BACKUP}" ]; do
-    ZSHRC_BACKUP="${ZSHRC_BACKUP}.backup"
-  done
-  ZSHRC_BACKUP_REL=$(realpath --relative-to="${HOME}" "${ZSHRC_BACKUP}")
-  echo "~/.zshrc exists, moving it to ~/${ZSHRC_BACKUP_REL}"
-  mv ${HOME}/.zshrc ${ZSHRC_BACKUP}
-fi
 
-NO_ZSHRC=false
-if [ -f "${HOME}/.zshrc" ]; then
-  NO_ZSHRC=true
-else
-  curl -fsSL https://raw.githubusercontent.com/STAOJ/sta-setup/master/.zshrc > ${HOME}/.zshrc
-fi
+#######################################
+# Installs the latest gcc version from brew.
+# Globals:
+#   HOMEBREW_PREFIX
+# Arguments:
+#   None
+#######################################
 
-if [ -f "${HOME}/.p10k.zsh" ]; then
-  P10K_BACKUP="${HOME}/.p10k.zsh.backup"
-  while [ -f "${P10K_BACKUP}" ]; do
-    P10K_BACKUP="${P10K_BACKUP}.backup"
-  done
-  P10K_BACKUP_REL=$(realpath --relative-to="${HOME}" "${P10K_BACKUP}")
-  echo "~/.p10k.zsh exists, moving it to ~/${P10K_BACKUP_REL}"
-  mv ${HOME}/.p10k.zsh ${P10K_BACKUP}
-fi
+stasetup::install_gcc () {
+    brew install --force-bottle gcc
+    cd ${HOMEBREW_PREFIX}/bin
+    ln -s gcc-11 gcc 
+    ln -s g++-11 g++ 
+    ln -s cpp-11 cpp 
+    ln -s c++-11 c++
+}
 
-NO_P10K=false
-if [ -f "${HOME}/.p10k.zsh" ]; then
-  NO_P10K=true 
-else
-  curl -fsSL https://raw.githubusercontent.com/STAOJ/sta-setup/master/.p10k.zsh > ${HOME}/.p10k.zsh
-fi
+#######################################
+# Install zsh using brew, and configure.
+# Globals:
+#   HOME
+#   HOMEBREW_PREFIX
+#   BASH_VERSION
+#   ZSH_VERSION
+# Arguments:
+#   None
+#######################################
 
-if [ "$NO_SHELL" = true ]; then
-  echo "Install successful, you don't seem to be using either bash or zsh so we can't figure out how to change your shell to zsh. Using zsh is not necessary, but it has some nice things installed like syntax highlighting and auto completion"
-fi
+stasetup::install_zsh () {
+    ## copied from old setup script, with brew bits removed
+    cd ${HOME}
+    NO_SHELL=false
+    if [ -n "$BASH_VERSION" ]; then
+    echo "$(which zsh)" >> ${HOME}/.bashrc
+    elif [ -n "$ZSH_VERSION" ]; then
+    :
+    else
+    NO_SHELL=true
+    fi
 
-if [ "$NO_ZSHRC" = true ]; then
-  echo "~/.zshrc already exists and we are unable to create an backup of it. So the recommended ~/.zshrc was not installed. To install it, consider removing your ~/.zshrc and run \n    curl -fsSL https://raw.githubusercontent.com/STAOJ/sta-setup/master/.zshrc > ${HOME}/.zshrc"
-fi
+    git clone https://github.com/ohmyzsh/ohmyzsh.git ${HOME}/.oh-my-zsh
+    git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
+    git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
 
-if [ "$NO_P10K" = true ]; then 
-  echo "~/.p10k.zsh already exists and we are unable to create an backup of it. So the recommended ~/.p10k.zsh was not installed. To install it, consider removing your ~/.p10k.configure and run \n     curl -fsSL https://raw.githubusercontent.com/STAOJ/sta-setup/master/.p10k.zsh > ${HOME}/.p10k.zsh"
+    if [ -f "${HOME}/.zshrc" ]; then
+    ZSHRC_BACKUP="${HOME}/.zshrc.backup"
+    while [ -f "${ZSHRC_BACKUP}" ]; do
+        ZSHRC_BACKUP="${ZSHRC_BACKUP}.backup"
+    done
+    ZSHRC_BACKUP_REL=$(realpath --relative-to="${HOME}" "${ZSHRC_BACKUP}")
+    echo "~/.zshrc exists, moving it to ~/${ZSHRC_BACKUP_REL}"
+    mv ${HOME}/.zshrc ${ZSHRC_BACKUP}
+    fi
+
+    NO_ZSHRC=false
+    if [ -f "${HOME}/.zshrc" ]; then
+    NO_ZSHRC=true
+    else
+    curl -fsSL https://raw.githubusercontent.com/STAOJ/sta-setup/master/.zshrc > ${HOME}/.zshrc
+    fi
+
+    if [ -f "${HOME}/.p10k.zsh" ]; then
+    P10K_BACKUP="${HOME}/.p10k.zsh.backup"
+    while [ -f "${P10K_BACKUP}" ]; do
+        P10K_BACKUP="${P10K_BACKUP}.backup"
+    done
+    P10K_BACKUP_REL=$(realpath --relative-to="${HOME}" "${P10K_BACKUP}")
+    echo "~/.p10k.zsh exists, moving it to ~/${P10K_BACKUP_REL}"
+    mv ${HOME}/.p10k.zsh ${P10K_BACKUP}
+    fi
+
+    NO_P10K=false
+    if [ -f "${HOME}/.p10k.zsh" ]; then
+    NO_P10K=true 
+    else
+    curl -fsSL https://raw.githubusercontent.com/STAOJ/sta-setup/master/.p10k.zsh > ${HOME}/.p10k.zsh
+    fi
+
+    if [ "$NO_SHELL" = true ]; then
+    echo "Install successful, you don't seem to be using either bash or zsh so we can't figure out how to change your shell to zsh. Using zsh is not necessary, but it has some nice things installed like syntax highlighting and auto completion"
+    fi
+
+    if [ "$NO_ZSHRC" = true ]; then
+    echo "~/.zshrc already exists and we are unable to create an backup of it. So the recommended ~/.zshrc was not installed. To install it, consider removing your ~/.zshrc and run \n    curl -fsSL https://raw.githubusercontent.com/STAOJ/sta-setup/master/.zshrc > ${HOME}/.zshrc"
+    fi
+
+    if [ "$NO_P10K" = true ]; then 
+    echo "~/.p10k.zsh already exists and we are unable to create an backup of it. So the recommended ~/.p10k.zsh was not installed. To install it, consider removing your ~/.p10k.configure and run \n     curl -fsSL https://raw.githubusercontent.com/STAOJ/sta-setup/master/.p10k.zsh > ${HOME}/.p10k.zsh"
+    fi
+}
+
+
+usage () {
+    echo "setup.sh -hB
+    
+    Options:
+    -h  Show this help message, and exit.
+    -B  Only install brew not zsh.
+    "
+}
+
+# run if the script is directly executed (not sourced)
+if [ "${BASH_SOURCE[0]}" == "$0" ]; then 
+    install_zsh=$(true)
+    
+    while getopts "hB" arg; do
+        case $arg in
+            h) usage; exit 0;;
+            B) install_zsh=$(false);;
+            *) echo "invalid arguments"; usage; exit 1;;
+        esac
+    done
+
+    echo "Installing brew"
+    stasetup::install_brew
+    stasetup::install_gcc
+    
+    if [[ $install_zsh = true ]]; then
+        echo "Installing zsh"
+        stasetup::install_zsh
+    fi
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -119,12 +119,12 @@ usage () {
 
 # run if the script is directly executed (not sourced)
 if [ "${BASH_SOURCE[0]}" == "$0" ]; then 
-    install_zsh=$(true)
+    install_zsh=true
     
     while getopts "hB" arg; do
         case $arg in
             h) usage; exit 0;;
-            B) install_zsh=$(false);;
+            B) install_zsh=false;;
             *) echo "invalid arguments"; usage; exit 1;;
         esac
     done
@@ -132,7 +132,7 @@ if [ "${BASH_SOURCE[0]}" == "$0" ]; then
     echo "Installing brew"
     stasetup::install_brew
     
-    if [[ $install_zsh = true ]]; then
+    if [ "$install_zsh" = true ]; then
         echo "Installing zsh"
         stasetup::install_zsh
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -41,7 +41,6 @@ grep -qx "$1" "$2" || echo "$1" >> "$2"
 #######################################
 
 stasetup::install_brew () {
-    set -e 
     originaldir=$(pwd)
     if [ ! -d "$HOME/.linuxbrew" ]; then
         git clone https://github.com/Homebrew/brew "$HOME/.linuxbrew"
@@ -61,7 +60,6 @@ stasetup::install_brew () {
     add_to_rc 'eval "$($HOME/.linuxbrew/bin/brew shellenv)"'
 
     cd "$originaldir"
-    set +e
 }
 
 #######################################

--- a/setup.sh
+++ b/setup.sh
@@ -82,9 +82,9 @@ stasetup::install_zsh () {
     cd ${HOME}
     NO_SHELL=false
     if [ -n "$BASH_VERSION" ]; then
-    echo "$(which zsh)" >> ${HOME}/.bashrc
+        append_if_not_present "$(which zsh)" "${HOME}/.bashrc"
     elif [ -n "$ZSH_VERSION" ]; then
-    :
+        :
     else
     NO_SHELL=true
     fi
@@ -145,7 +145,7 @@ stasetup::install_zsh () {
 
 
 usage () {
-    echo "setup.sh -hB
+    echo "setup.sh [-hB]
     
     FLAGS:
       -h  Show this help message, and exit.

--- a/setup.sh
+++ b/setup.sh
@@ -13,8 +13,9 @@
 #######################################
 
 stasetup::install_brew () {
+    originaldir=$(pwd)
     git clone https://github.com/Homebrew/brew ${HOME}/.linuxbrew
-    .linuxbrew/bin/brew update --force --quiet
+    ${HOME}/.linuxbrew/bin/brew update --force --quiet
     eval "$(${HOME}/.linuxbrew/bin/brew shellenv)"
     brew install --force-bottle binutils
     brew install --force-bottle gcc
@@ -23,6 +24,8 @@ stasetup::install_brew () {
     ln -s g++-11 g++ 
     ln -s cpp-11 cpp 
     ln -s c++-11 c++
+
+    cd "$originaldir"
 }
 
 #######################################
@@ -37,6 +40,8 @@ stasetup::install_brew () {
 #######################################
 
 stasetup::install_zsh () {
+    originaldir=$(pwd)
+    
     ## copied from old setup script, with brew bits removed
     cd ${HOME}
     NO_SHELL=false
@@ -98,6 +103,8 @@ stasetup::install_zsh () {
     if [ "$NO_P10K" = true ]; then 
     echo "~/.p10k.zsh already exists and we are unable to create an backup of it. So the recommended ~/.p10k.zsh was not installed. To install it, consider removing your ~/.p10k.configure and run \n     curl -fsSL https://raw.githubusercontent.com/STAOJ/sta-setup/master/.p10k.zsh > ${HOME}/.p10k.zsh"
     fi
+
+    cd "$originaldir"
 }
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -17,18 +17,6 @@ stasetup::install_brew () {
     .linuxbrew/bin/brew update --force --quiet
     eval "$(${HOME}/.linuxbrew/bin/brew shellenv)"
     brew install --force-bottle binutils
-}
-
-
-#######################################
-# Installs the latest gcc version from brew.
-# Globals:
-#   HOMEBREW_PREFIX
-# Arguments:
-#   None
-#######################################
-
-stasetup::install_gcc () {
     brew install --force-bottle gcc
     cd ${HOMEBREW_PREFIX}/bin
     ln -s gcc-11 gcc 

--- a/setup.sh
+++ b/setup.sh
@@ -51,10 +51,10 @@ stasetup::install_brew () {
     brew install --force-bottle binutils
     brew install --force-bottle gcc
     cd "$HOMEBREW_PREFIX/bin"
-    ln -sf gcc-11 gcc 
-    ln -sf g++-11 g++ 
-    ln -sf cpp-11 cpp 
-    ln -sf c++-11 c++
+    [ -e gcc ] || ln -s gcc-11 gcc 
+    [ -e g++ ] || ln -s g++-11 g++ 
+    [ -e cpp ] || ln -s cpp-11 cpp 
+    [ -e c++ ] || ln -s c++-11 c++
 
 
     add_to_rc 'eval "$($HOME/.linuxbrew/bin/brew shellenv)"'

--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,34 @@
 # Usage: see -h / usage()
 
 #######################################
+# Adds the specified string to the shell-rc files if it doesn't already exist.
+# This adds the specified string to both .zshrc and .bashrc if they exist.
+# Globals:
+#   HOME
+# Arguments:
+#   $1: the string to be added to .bashrc.
+#######################################
+
+add_to_rc () {
+    for shell_file in "$HOME/.bashrc" "$HOME/.zshrc"; do
+        if  [ -f "$shell_file" ]; then
+            append_if_not_present $1 $shell_file
+        fi
+    done
+}
+
+#######################################
+# Adds the given string to the given file if it doesn't already exist.
+# Arguments:
+#   $1: the string to be added to the file.
+#   $2: the path to the file.
+#######################################
+
+append_if_not_present () {
+grep -qx $1 $2 || echo $1 >> $2
+}
+
+#######################################
 # Installs brew under the local user from git.
 # Globals:
 #   HOME
@@ -13,19 +41,25 @@
 #######################################
 
 stasetup::install_brew () {
+    set -e 
     originaldir=$(pwd)
+
     git clone https://github.com/Homebrew/brew ${HOME}/.linuxbrew
-    ${HOME}/.linuxbrew/bin/brew update --force --quiet
-    eval "$(${HOME}/.linuxbrew/bin/brew shellenv)"
+    $HOME/.linuxbrew/bin/brew update --force --quiet
+    eval "$($HOME/.linuxbrew/bin/brew shellenv)"
     brew install --force-bottle binutils
     brew install --force-bottle gcc
-    cd ${HOMEBREW_PREFIX}/bin
+    cd "$HOMEBREW_PREFIX/bin"
     ln -s gcc-11 gcc 
     ln -s g++-11 g++ 
     ln -s cpp-11 cpp 
     ln -s c++-11 c++
 
+
+    add_to_rc 'eval "$($HOME/.linuxbrew/bin/brew shellenv)"'
+
     cd "$originaldir"
+    set +e
 }
 
 #######################################
@@ -111,9 +145,9 @@ stasetup::install_zsh () {
 usage () {
     echo "setup.sh -hB
     
-    Options:
-    -h  Show this help message, and exit.
-    -B  Only install brew not zsh.
+    FLAGS:
+      -h  Show this help message, and exit.
+      -B  Only install brew not zsh.
     "
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -118,9 +118,20 @@ usage () {
 }
 
 # run if the script is directly executed (not sourced)
-if [ "${BASH_SOURCE[0]}" == "$0" ]; then 
+
+ # See https://stackoverflow.com/a/28776166
+ is_sourced() {
+   if [ -n "$ZSH_VERSION" ]; then 
+       case $ZSH_EVAL_CONTEXT in *:file:*) return 0;; esac
+   else  # Add additional POSIX-compatible shell names here, if needed.
+       case ${0##*/} in dash|-dash|bash|-bash|ksh|-ksh|sh|-sh) return 0;; esac
+   fi
+   return 1  # NOT sourced.
+ }
+
+
+if [ "$(is_sourced)" = true ]; then 
     install_zsh=true
-    
     while getopts "hB" arg; do
         case $arg in
             h) usage; exit 0;;


### PR DESCRIPTION
This PR adds an option to install brew without zsh. This can be done through the `setup.sh -B` flag.

To this end, I have also refactored the script into functions, and added argument parsing.

The script also can now be sourced and the main code not ran, allowing it to be used as a library in other shell scripts.